### PR TITLE
feat: integrar ProgresoService y Checklist diario

### DIFF
--- a/frontend/src/app/pages/habitos/habitos.html
+++ b/frontend/src/app/pages/habitos/habitos.html
@@ -35,11 +35,11 @@
                 </button>
                 <button class="tab-button" [class.active]="activeTab === 'hidratacion'"
                   (click)="setActiveTab('hidratacion')">
-                 <i class="fa-solid fa-glass-water"></i> Hidratación
+                  <i class="fa-solid fa-glass-water"></i> Hidratación
                 </button>
                 <button class="tab-button" [class.active]="activeTab === 'alimentacion'"
                   (click)="setActiveTab('alimentacion')">
-                 <i class="fa-solid fa-utensils"></i> Alimentación
+                  <i class="fa-solid fa-utensils"></i> Alimentación
                 </button>
                 <button class="tab-button" [class.active]="activeTab === 'sueno'" (click)="setActiveTab('sueno')">
                   <i class="fa-solid fa-bed"></i> Sueño
@@ -63,67 +63,29 @@
                 </article>
                 @if (mostrarRutina) {
                 <div class="listado__crud">
-                  <h3>Mi Rutina de Ejercicio</h3>
+                  <h3>Mi Checklist Diario</h3>
                   <ul>
-                    @for (habito of habitos; track habito.id) {
+                    @for (progreso of progresosDiarios; track progreso.id) {
                     <li>
-                      @if (habitoEnEdicion && habitoEnEdicion.id === habito.id) {
-                      <div class="edicion__habito">
-                        <h4>
-                          {{ habitoEnEdicion.nombre }} -
-                          {{ habitoEnEdicion.tipo }}
-                        </h4>
-                        <div class="edicion__container">
-                          <input [(ngModel)]="habitoEnEdicion.metaDiaria" type="text" />
-                          <div class="acciones__edicion">
-                            <button class="btn__icono aceptar" (click)="guardarEdicion()">
-                              <i class="fa-solid fa-check"></i>
-                            </button>
-                            <button class="btn__icono cancelar" (click)="cancelarEdicion()">
-                              <i class="fa-solid fa-xmark"></i>
-                            </button>
-                          </div>
-                        </div>
-                      </div>
+                      <div class="habito__display" [class.completado]="progreso.completado">
 
-                      } 
-                      
-                      @else {
-                      <div class="habito__display" [class.completado]="habito.completado">
-                        
                         <p class="habito__texto">
-                          {{ habito.nombre }} - {{ habito.tipo }} -
-                          {{ habito.metaDiaria }}
+                          {{ progreso.habito.nombre }}
                         </p>
-                        
-                        <div class="crud__acciones">
-                            
-                            @if (!habito.completado) {
-                            <button class="btn__icono editar" (click)="entrarEnModoEdicion(habito)">
-                              <i class="fa-solid fa-pen-to-square"></i>
-                            </button>
-                            <button class="btn__icono eliminar" (click)="eliminarHabito(habito.id)">
-                              <i class="fa-solid fa-xmark"></i>
-                            </button>
-                            }
 
-                            <label class="custom-checkbox-container" title="Marcar como completado">
-                                <input
-                                    type="checkbox"
-                                    [id]="'habito-check-' + habito.id"
-                                    [(ngModel)]="habito.completado"
-                                    (change)="marcarHabito(habito)"
-                                />
-                                <span class="checkmark"></span>
-                            </label>
+                        <div class="crud__acciones">
+                          <label class="custom-checkbox-container" title="Marcar como completado">
+                            <input type="checkbox" [id]="'progreso-check-' + progreso.id"
+                              [(ngModel)]="progreso.completado" (change)="marcarHabito(progreso)" />
+                            <span class="checkmark"></span>
+                          </label>
                         </div>
                       </div>
-                      }
                     </li>
                     }
 
                     @empty {
-                    <li class="lista-vacia">No tienes hábitos agregados a tu rutina.</li>
+                    <li class="lista-vacia">No hay hábitos definidos para tu checklist de hoy.</li>
                     }
                   </ul>
                 </div>

--- a/frontend/src/app/services/progreso.ts
+++ b/frontend/src/app/services/progreso.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 export interface Habito {
@@ -19,24 +19,46 @@ export interface ProgresoDiario {
   providedIn: 'root',
 })
 export class ProgresoService {
-
-  private baseUrl = 'http://localhost:8000/api'; 
+  private baseUrl = 'http://localhost:8000/api/progresos';
 
   constructor(private http: HttpClient) {}
 
   getProgresoDiario(usuarioId: number): Observable<ProgresoDiario[]> {
-    return this.http.get<ProgresoDiario[]>(`${this.baseUrl}/progreso/?usuario_id=${usuarioId}`);
+    return this.http.get<ProgresoDiario[]>(
+      `${this.baseUrl}/progreso/?usuario_id=${usuarioId}`
+    );
   }
 
   marcarCompletado(id: number, completado: boolean): Observable<any> {
     return this.http.patch(`${this.baseUrl}/${id}/`, { completado });
   }
 
-
   actualizarProgreso(progresoId: number, completado: boolean): Observable<any> {
     return this.http.patch(`${this.baseUrl}/progreso/`, {
       progreso_id: progresoId,
       completado: completado,
     });
+  }
+
+  obtenerChecklist(fecha?: string): Observable<ProgresoDiario[]> {
+    let params = new HttpParams();
+    // Si hay fecha, la agregamos como query parameter
+    if (fecha) {
+      params = params.set('fecha', fecha);
+    }
+    return this.http.get<ProgresoDiario[]>(`${this.baseUrl}checklist/`, {
+      params,
+    });
+  }
+
+  toggleCompletado(
+    progresoId: number,
+    completado: boolean
+  ): Observable<ProgresoDiario> {
+    // La URL debe ser específica para el recurso: /progresos/<id>/toggle/
+    return this.http.patch<ProgresoDiario>(
+      `${this.baseUrl}${progresoId}/toggle/`,
+      { completado }
+    );
   }
 }


### PR DESCRIPTION
Añade la integración completa del Progreso Diario (Checklist) para el usuario.

Backend (Django):
- Crea el endpoint GET /api/progresos/checklist/ que llama al ProgresoDiarioManager.asegurar_progresos_para_usuario para generar los registros diarios automáticamente.
- Implementa el endpoint PATCH /api/progresos/<pk>/toggle/ para actualizar el estado 'completado'.
- Asegura que ambos endpoints utilicen IsAuthenticated.

Frontend (Angular):
- Integra ProgresoService para obtener y actualizar el checklist.
- Modifica HabitosComponent y HabitosService para consumir las nuevas rutas RESTful.